### PR TITLE
[WIP] make correction to broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.kittinunf:remote-redux-devtools-android:1.0.0.alpha8'
+  implementation "com.github.kittinunf.remote-redux-devtools-android:core:1.0.0.alpha8"
 }
 ```


### PR DESCRIPTION
The link in README doesn't work 👮🚓 
```
  implementation 'com.github.kittinunf:remote-redux-devtools-android:1.0.0.alpha8'
```

So I fixed it in this PR 🐸 

oh wait, this fix doesn't work either... it's including `/core` but not `/lib` 💦 